### PR TITLE
removed in app update checker and added github workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,45 @@
+name: Android Build APK
+
+on:
+  push:
+    branches: [ "experimental", "main" ]
+  pull_request:
+    branches: [ "experimental", "main" ]
+  workflow_dispatch: # Allows manual triggering from the Actions tab
+
+jobs:
+  build:
+    name: Build Android APK
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: 'gradle'
+
+    - name: Grant Execute Permission to Gradlew
+      run: chmod +x gradlew
+
+    - name: Build Debug APK
+      run: ./gradlew assembleDebug
+
+    - name: Build Release APK
+      run: ./gradlew assembleRelease
+
+    - name: Upload Debug APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: debug-apk
+        path: app/build/outputs/apk/debug/app-debug.apk
+
+    - name: Upload Release APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-apk
+        path: app/build/outputs/apk/release/*.apk

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+      - experimental
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.8"

--- a/app/src/main/java/com/material/downloader/MainActivity.kt
+++ b/app/src/main/java/com/material/downloader/MainActivity.kt
@@ -58,53 +58,6 @@ class MainActivity : ComponentActivity() {
                 handleIntent(intent, viewModel)
             }
 
-            val updateUrl = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf<String?>(null) }
-            val updateVersion = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf<String?>(null) }
-
-            LaunchedEffect(Unit) {
-                kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-                    try {
-                        val url = java.net.URL("https://api.github.com/repos/Hotaro26/gabi/releases/latest")
-                        val connection = url.openConnection() as java.net.HttpURLConnection
-                        connection.requestMethod = "GET"
-                        if (connection.responseCode == 200) {
-                            val response = connection.inputStream.bufferedReader().use { it.readText() }
-                            val json = org.json.JSONObject(response)
-                            val tagName = json.getString("tag_name")
-                            val htmlUrl = json.getString("html_url")
-                            val currentVersion = "v${BuildConfig.VERSION_NAME}"
-                            if (tagName != currentVersion) {
-                                updateVersion.value = tagName
-                                updateUrl.value = htmlUrl
-                            }
-                        }
-                    } catch (e: Exception) { e.printStackTrace() }
-                }
-            }
-
-            if (updateUrl.value != null && updateVersion.value != null) {
-                androidx.compose.material3.AlertDialog(
-                    onDismissRequest = { updateUrl.value = null },
-                    title = { androidx.compose.material3.Text("Update Available") },
-                    text = { androidx.compose.material3.Text("A new version (${updateVersion.value}) of Gabi is available. Would you like to update?") },
-                    confirmButton = {
-                        androidx.compose.material3.TextButton(onClick = {
-                            val updateIntent = android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse(updateUrl.value))
-                            updateIntent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
-                            startActivity(updateIntent)
-                            updateUrl.value = null
-                        }) {
-                            androidx.compose.material3.Text("Update")
-                        }
-                    },
-                    dismissButton = {
-                        androidx.compose.material3.TextButton(onClick = { updateUrl.value = null }) {
-                            androidx.compose.material3.Text("Dismiss")
-                        }
-                    }
-                )
-            }
-
 
             val darkTheme = when (viewModel.themeMode.intValue) {
                 1 -> false


### PR DESCRIPTION
## Summary by Sourcery

Remove the in-app update checker and introduce basic GitHub Actions workflows for building APKs and deploying GitHub Pages.

Enhancements:
- Enable BuildConfig generation for the Android app module.

Build:
- Add GitHub Actions workflow to build debug and release Android APKs and upload them as artifacts.

CI:
- Introduce GitHub Pages deployment workflow triggered on pushes to master and experimental branches.

Deployment:
- Configure automated deployment of the repository content to GitHub Pages via Actions.